### PR TITLE
Added getting of the latest project version

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,15 +1,6 @@
 # Modrinth.py
 Interact with Modrinth's Labrinth API through Python. 
 
-## API Version
-
- Service              | Version
-----------------------|----------
- Modrinth.py version  | v0.1.3
- Labrinth API version | v2.4.4
-
-*Modrinth.py works on the latest Labrinth version!*
-
 ## To-do
  - [x] Search for projects
  - [x] (Un)follow projects
@@ -26,7 +17,7 @@ Interact with Modrinth's Labrinth API through Python.
  - [ ] Upload files to version
  - [ ] Get a version from `sha1` or `sha512`
  - [ ] Delete a file from its hash (DELETE requests to `/version_file`)
- - [ ] Get latest project(s) version(s)
+ - [x] Get latest project(s) version(s)
  - [ ] Get project version from hash
  - [x] Read user(s) data
  - [ ] Delete and modify user data

--- a/modrinth/__init__.py
+++ b/modrinth/__init__.py
@@ -150,6 +150,12 @@ class Projects:
             headers = {'Authorization': user.token}
             requests.delete(url, headers=headers)
 
+        def getLatestVersion(self):
+            '''
+            Gets the latest version for the current project.
+            '''
+            return Versions.getLatestVersion(self)
+
         def getVersion(self, version):
             '''
             Shorthand for Versions.ModrinthVersion with no project argument.
@@ -160,7 +166,7 @@ class Projects:
             '''
             Get Versions.getVersions() for all versions found for the project. 
             '''
-            return Versions.getVersions(self.versions)
+            return Versions.getVersions(self, self.versions)
 
     def getProjects(ids: list) -> list:
         '''
@@ -317,3 +323,9 @@ class Versions:
         Get a list of versions, given a list of IDs.
         '''
         return [Versions.ModrinthVersion(project, id) for id in ids]
+    
+    def getLatestVersion(project: Projects.ModrinthProject) -> ModrinthVersion:
+        '''
+        Gets the latest version, given a project.
+        '''
+        return project.getAllVersions()[-1]


### PR DESCRIPTION
You can now get the latest version of a project, like so:

```py
import modrinth

project = modrinth.Projects.ModrinthProject('sodium')
print(project.getLatestVersion().name)

```

Fixes #8